### PR TITLE
MCPDB-2: Add execute_query tool for read-only SQL

### DIFF
--- a/src/db/adapter.ts
+++ b/src/db/adapter.ts
@@ -34,4 +34,7 @@ export interface IDbAdapter {
   update(table: string, id: number, record: Partial<Record<string, unknown>>): Promise<void>;
   delete(table: string, id: number): Promise<void>;
   count(table: string, filters?: QueryFilter[]): Promise<number>;
+
+  // Raw SQL (SELECT/WITH only)
+  execute(sql: string, params?: (string | number | boolean)[]): Promise<Record<string, unknown>[]>;
 }

--- a/src/db/sqlite.ts
+++ b/src/db/sqlite.ts
@@ -129,6 +129,14 @@ export class SqliteAdapter implements IDbAdapter {
     return row.cnt;
   }
 
+  async execute(sql: string, params: (string | number | boolean)[] = []): Promise<Record<string, unknown>[]> {
+    const prefix = sql.trimStart().toUpperCase();
+    if (!prefix.startsWith("SELECT") && !prefix.startsWith("WITH")) {
+      throw new Error("Only SELECT and WITH (CTE) statements are allowed");
+    }
+    return this.db.query(sql).all(...params) as Record<string, unknown>[];
+  }
+
   private mapSqliteType(sqliteType: string): "text" | "integer" | "real" | "boolean" {
     const t = sqliteType.toUpperCase();
     if (t.includes("INT")) return "integer";

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import { Logger } from "./logger.ts";
 import { registerDatabaseTools } from "./tools/database.ts";
 import { registerSchemaTools } from "./tools/schema.ts";
 import { registerRecordTools } from "./tools/records.ts";
+import { registerQueryTools } from "./tools/query.ts";
 
 export async function createServer(config: Config) {
   const registry = new DatabaseRegistry(config.DATA_DIR);
@@ -19,6 +20,7 @@ export async function createServer(config: Config) {
   registerDatabaseTools(server as Parameters<typeof registerDatabaseTools>[0], registry, logger);
   registerSchemaTools(server as Parameters<typeof registerSchemaTools>[0], registry, logger);
   registerRecordTools(server as Parameters<typeof registerRecordTools>[0], registry, logger);
+  registerQueryTools(server as Parameters<typeof registerQueryTools>[0], registry, logger);
 
   return { server, registry, logger };
 }

--- a/src/tools/query.ts
+++ b/src/tools/query.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import type { DatabaseRegistry } from "../db/registry.ts";
+import type { Logger } from "../logger.ts";
+
+type ToolServer = {
+  tool: (name: string, description: string, schema: object, handler: (args: unknown) => Promise<unknown>) => void;
+};
+
+function getAdapter(registry: DatabaseRegistry, database: string) {
+  if (!registry.exists(database)) throw new Error(`Database "${database}" does not exist`);
+  return registry.get(database);
+}
+
+function errorResponse(message: string) {
+  return { content: [{ type: "text", text: JSON.stringify({ error: message }) }], isError: true };
+}
+
+export function registerQueryTools(server: ToolServer, registry: DatabaseRegistry, logger: Logger) {
+  server.tool(
+    "execute_query",
+    "Execute a read-only SQL query (SELECT/WITH) against a database. Supports joins, aggregates, GROUP BY, subqueries, and CTEs.",
+    {
+      database: z.string(),
+      sql: z.string(),
+      params: z.array(z.union([z.string(), z.number(), z.boolean()])).optional(),
+    },
+    async (args: unknown) => {
+      const { database, sql, params } = args as { database: string; sql: string; params?: (string | number | boolean)[] };
+      return logger.wrap("execute_query", args, async () => {
+        try {
+          const adapter = getAdapter(registry, database);
+          const rows = await adapter.execute(sql, params);
+          return { content: [{ type: "text", text: JSON.stringify({ rows, count: rows.length }) }] };
+        } catch (err) {
+          return errorResponse(err instanceof Error ? err.message : String(err));
+        }
+      });
+    }
+  );
+}

--- a/tests/sqlite-adapter.test.ts
+++ b/tests/sqlite-adapter.test.ts
@@ -129,6 +129,57 @@ describe("SqliteAdapter", () => {
     });
   });
 
+  describe("execute", () => {
+    beforeEach(async () => {
+      await adapter.createTable({
+        name: "fruits",
+        columns: [
+          { name: "name", type: "text", required: true },
+          { name: "weight", type: "real" },
+        ],
+      });
+      await adapter.insert("fruits", { name: "apple", weight: 0.3 });
+      await adapter.insert("fruits", { name: "banana", weight: 0.2 });
+    });
+
+    it("runs a SELECT query", async () => {
+      const rows = await adapter.execute("SELECT * FROM fruits");
+      expect(rows.length).toBe(2);
+    });
+
+    it("supports bind params", async () => {
+      const rows = await adapter.execute("SELECT * FROM fruits WHERE name = ?", ["apple"]);
+      expect(rows.length).toBe(1);
+      expect(rows[0]!["name"]).toBe("apple");
+    });
+
+    it("allows WITH (CTE) queries", async () => {
+      const rows = await adapter.execute(
+        "WITH heavy AS (SELECT * FROM fruits WHERE weight > 0.25) SELECT name FROM heavy"
+      );
+      expect(rows.length).toBe(1);
+      expect(rows[0]!["name"]).toBe("apple");
+    });
+
+    it("rejects INSERT", async () => {
+      expect(adapter.execute("INSERT INTO fruits (name) VALUES ('pear')")).rejects.toThrow(
+        /Only SELECT and WITH/
+      );
+    });
+
+    it("rejects DELETE", async () => {
+      expect(adapter.execute("DELETE FROM fruits WHERE id = 1")).rejects.toThrow(
+        /Only SELECT and WITH/
+      );
+    });
+
+    it("rejects DROP", async () => {
+      expect(adapter.execute("DROP TABLE fruits")).rejects.toThrow(
+        /Only SELECT and WITH/
+      );
+    });
+  });
+
   describe("count", () => {
     it("counts all records", async () => {
       await adapter.createTable({

--- a/tests/tools-query.test.ts
+++ b/tests/tools-query.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { rmSync, existsSync } from "fs";
+import { DatabaseRegistry } from "../src/db/registry.ts";
+import { Logger } from "../src/logger.ts";
+import { registerQueryTools } from "../src/tools/query.ts";
+
+const TEST_DIR = "/tmp/test-instant-db-tools-query";
+const TEST_LOG = "/tmp/test-instant-db-tools-query.log";
+
+function cleanup() {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  if (existsSync(TEST_LOG)) rmSync(TEST_LOG);
+}
+
+function makeFakeServer() {
+  const tools: Record<string, (args: unknown) => Promise<unknown>> = {};
+  return {
+    tool(name: string, _desc: string, _schema: object, handler: (args: unknown) => Promise<unknown>) {
+      tools[name] = handler;
+    },
+    call(name: string, args: unknown) {
+      const fn = tools[name];
+      if (!fn) throw new Error(`Tool ${name} not registered`);
+      return fn(args);
+    },
+  };
+}
+
+beforeEach(cleanup);
+afterEach(cleanup);
+
+describe("execute_query tool", () => {
+  let server: ReturnType<typeof makeFakeServer>;
+  let registry: DatabaseRegistry;
+  let logger: Logger;
+
+  beforeEach(async () => {
+    registry = new DatabaseRegistry(TEST_DIR);
+    logger = new Logger({ LOG_LEVEL: "off", LOG_PATH: TEST_LOG });
+    server = makeFakeServer();
+    registerQueryTools(server, registry, logger);
+
+    // Seed a database with tables for tests
+    const adapter = await registry.create("testdb");
+    await adapter.createTable({
+      name: "fruits",
+      columns: [
+        { name: "name", type: "text", required: true },
+        { name: "weight", type: "real" },
+        { name: "color", type: "text" },
+      ],
+    });
+    await adapter.createTable({
+      name: "orders",
+      columns: [
+        { name: "fruit_id", type: "integer", required: true },
+        { name: "quantity", type: "integer", required: true },
+      ],
+    });
+
+    await adapter.insert("fruits", { name: "apple", weight: 0.3, color: "red" });
+    await adapter.insert("fruits", { name: "banana", weight: 0.2, color: "yellow" });
+    await adapter.insert("fruits", { name: "cherry", weight: 0.01, color: "red" });
+
+    await adapter.insert("orders", { fruit_id: 1, quantity: 10 });
+    await adapter.insert("orders", { fruit_id: 2, quantity: 5 });
+    await adapter.insert("orders", { fruit_id: 1, quantity: 3 });
+  });
+
+  it("basic SELECT returns rows", async () => {
+    const result = await server.call("execute_query", {
+      database: "testdb",
+      sql: "SELECT * FROM fruits",
+    }) as { content: { text: string }[] };
+
+    const data = JSON.parse(result.content[0]!.text);
+    expect(data.count).toBe(3);
+    expect(data.rows).toHaveLength(3);
+  });
+
+  it("SELECT with WHERE clause", async () => {
+    const result = await server.call("execute_query", {
+      database: "testdb",
+      sql: "SELECT * FROM fruits WHERE color = 'red'",
+    }) as { content: { text: string }[] };
+
+    const data = JSON.parse(result.content[0]!.text);
+    expect(data.count).toBe(2);
+    expect(data.rows.every((r: Record<string, unknown>) => r.color === "red")).toBe(true);
+  });
+
+  it("SELECT with JOIN across tables", async () => {
+    const result = await server.call("execute_query", {
+      database: "testdb",
+      sql: `SELECT f.name, o.quantity
+            FROM orders o
+            JOIN fruits f ON f.id = o.fruit_id
+            ORDER BY o.quantity DESC`,
+    }) as { content: { text: string }[] };
+
+    const data = JSON.parse(result.content[0]!.text);
+    expect(data.count).toBe(3);
+    expect(data.rows[0].name).toBe("apple");
+    expect(data.rows[0].quantity).toBe(10);
+  });
+
+  it("SELECT with aggregate (COUNT, SUM)", async () => {
+    const result = await server.call("execute_query", {
+      database: "testdb",
+      sql: `SELECT f.name, COUNT(*) as order_count, SUM(o.quantity) as total_qty
+            FROM orders o
+            JOIN fruits f ON f.id = o.fruit_id
+            GROUP BY f.name
+            ORDER BY total_qty DESC`,
+    }) as { content: { text: string }[] };
+
+    const data = JSON.parse(result.content[0]!.text);
+    expect(data.count).toBe(2);
+    expect(data.rows[0].name).toBe("apple");
+    expect(data.rows[0].total_qty).toBe(13);
+    expect(data.rows[0].order_count).toBe(2);
+  });
+
+  it("bind params work correctly", async () => {
+    const result = await server.call("execute_query", {
+      database: "testdb",
+      sql: "SELECT * FROM fruits WHERE color = ? AND weight > ?",
+      params: ["red", 0.05],
+    }) as { content: { text: string }[] };
+
+    const data = JSON.parse(result.content[0]!.text);
+    expect(data.count).toBe(1);
+    expect(data.rows[0].name).toBe("apple");
+  });
+
+  it("rejects INSERT statement", async () => {
+    const result = await server.call("execute_query", {
+      database: "testdb",
+      sql: "INSERT INTO fruits (name) VALUES ('pear')",
+    }) as { isError: boolean; content: { text: string }[] };
+
+    expect(result.isError).toBe(true);
+    const data = JSON.parse(result.content[0]!.text);
+    expect(data.error).toMatch(/Only SELECT and WITH/);
+  });
+
+  it("rejects UPDATE statement", async () => {
+    const result = await server.call("execute_query", {
+      database: "testdb",
+      sql: "UPDATE fruits SET name = 'pear' WHERE id = 1",
+    }) as { isError: boolean; content: { text: string }[] };
+
+    expect(result.isError).toBe(true);
+  });
+
+  it("rejects DELETE statement", async () => {
+    const result = await server.call("execute_query", {
+      database: "testdb",
+      sql: "DELETE FROM fruits WHERE id = 1",
+    }) as { isError: boolean; content: { text: string }[] };
+
+    expect(result.isError).toBe(true);
+  });
+
+  it("rejects DROP statement", async () => {
+    const result = await server.call("execute_query", {
+      database: "testdb",
+      sql: "DROP TABLE fruits",
+    }) as { isError: boolean; content: { text: string }[] };
+
+    expect(result.isError).toBe(true);
+  });
+
+  it("rejects ALTER statement", async () => {
+    const result = await server.call("execute_query", {
+      database: "testdb",
+      sql: "ALTER TABLE fruits ADD COLUMN taste TEXT",
+    }) as { isError: boolean; content: { text: string }[] };
+
+    expect(result.isError).toBe(true);
+  });
+
+  it("rejects non-existent database", async () => {
+    const result = await server.call("execute_query", {
+      database: "nope",
+      sql: "SELECT 1",
+    }) as { isError: boolean; content: { text: string }[] };
+
+    expect(result.isError).toBe(true);
+    const data = JSON.parse(result.content[0]!.text);
+    expect(data.error).toMatch(/does not exist/);
+  });
+
+  it("WITH (CTE) queries work", async () => {
+    const result = await server.call("execute_query", {
+      database: "testdb",
+      sql: `WITH red_fruits AS (
+              SELECT * FROM fruits WHERE color = 'red'
+            )
+            SELECT name, weight FROM red_fruits ORDER BY weight DESC`,
+    }) as { content: { text: string }[] };
+
+    const data = JSON.parse(result.content[0]!.text);
+    expect(data.count).toBe(2);
+    expect(data.rows[0].name).toBe("apple");
+    expect(data.rows[1].name).toBe("cherry");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `execute_query` MCP tool for running raw SELECT/WITH (CTE) queries against any database
- Enables joins, aggregates, GROUP BY, subqueries, and computed values in a single call
- Validates SQL prefix and rejects all write operations (INSERT/UPDATE/DELETE/DROP/ALTER)

## Changes
- `src/db/adapter.ts` — added `execute()` to `IDbAdapter` interface
- `src/db/sqlite.ts` — implemented `execute()` with SELECT/WITH prefix validation
- `src/tools/query.ts` — new `execute_query` tool (params: database, sql, optional bind params)
- `src/server.ts` — registered query tools
- `tests/sqlite-adapter.test.ts` — 6 adapter-level tests
- `tests/tools-query.test.ts` — 12 tool-level tests

## Test plan
- [x] `bun test` — 68 tests pass (18 new)
- [x] Manual: confirmed `execute_query` visible in Claude Desktop after server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)