### PR TITLE
Add execute_mutation tool for DML (MCPDB-3)

### DIFF
--- a/src/db/adapter.ts
+++ b/src/db/adapter.ts
@@ -37,4 +37,7 @@ export interface IDbAdapter {
 
   // Raw SQL (SELECT/WITH only)
   execute(sql: string, params?: (string | number | boolean)[]): Promise<Record<string, unknown>[]>;
+
+  // Raw DML (INSERT/UPDATE/DELETE only)
+  mutate(sql: string, params?: (string | number | boolean)[]): Promise<{ rowsAffected: number; lastInsertRowid: number }>;
 }

--- a/src/db/sqlite.ts
+++ b/src/db/sqlite.ts
@@ -129,6 +129,25 @@ export class SqliteAdapter implements IDbAdapter {
     return row.cnt;
   }
 
+  async mutate(sql: string, params: (string | number | boolean)[] = []): Promise<{ rowsAffected: number; lastInsertRowid: number }> {
+    const prefix = sql.trimStart().toUpperCase();
+    const allowed = ["INSERT", "UPDATE", "DELETE"];
+    const rejected = ["SELECT", "CREATE", "DROP", "ALTER", "TRUNCATE"];
+
+    if (rejected.some((k) => prefix.startsWith(k))) {
+      throw new Error(`Statement type not allowed. Only INSERT, UPDATE, DELETE are permitted.`);
+    }
+    if (!allowed.some((k) => prefix.startsWith(k))) {
+      throw new Error(`Statement type not allowed. Only INSERT, UPDATE, DELETE are permitted.`);
+    }
+
+    const txn = this.db.transaction(() => {
+      return this.db.query(sql).run(...params);
+    });
+    const result = txn();
+    return { rowsAffected: result.changes, lastInsertRowid: Number(result.lastInsertRowid) };
+  }
+
   async execute(sql: string, params: (string | number | boolean)[] = []): Promise<Record<string, unknown>[]> {
     const prefix = sql.trimStart().toUpperCase();
     if (!prefix.startsWith("SELECT") && !prefix.startsWith("WITH")) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import { registerDatabaseTools } from "./tools/database.ts";
 import { registerSchemaTools } from "./tools/schema.ts";
 import { registerRecordTools } from "./tools/records.ts";
 import { registerQueryTools } from "./tools/query.ts";
+import { registerMutationTools } from "./tools/mutation.ts";
 
 export async function createServer(config: Config) {
   const registry = new DatabaseRegistry(config.DATA_DIR);
@@ -21,6 +22,7 @@ export async function createServer(config: Config) {
   registerSchemaTools(server as Parameters<typeof registerSchemaTools>[0], registry, logger);
   registerRecordTools(server as Parameters<typeof registerRecordTools>[0], registry, logger);
   registerQueryTools(server as Parameters<typeof registerQueryTools>[0], registry, logger);
+  registerMutationTools(server as Parameters<typeof registerMutationTools>[0], registry, logger);
 
   return { server, registry, logger };
 }

--- a/src/tools/mutation.ts
+++ b/src/tools/mutation.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import type { DatabaseRegistry } from "../db/registry.ts";
+import type { Logger } from "../logger.ts";
+
+type ToolServer = {
+  tool: (name: string, description: string, schema: object, handler: (args: unknown) => Promise<unknown>) => void;
+};
+
+function getAdapter(registry: DatabaseRegistry, database: string) {
+  if (!registry.exists(database)) throw new Error(`Database "${database}" does not exist`);
+  return registry.get(database);
+}
+
+function errorResponse(message: string) {
+  return { content: [{ type: "text", text: JSON.stringify({ error: message }) }], isError: true };
+}
+
+export function registerMutationTools(server: ToolServer, registry: DatabaseRegistry, logger: Logger) {
+  server.tool(
+    "execute_mutation",
+    "Execute a DML statement (INSERT/UPDATE/DELETE) against a database. DDL and SELECT are rejected. Runs inside a transaction.",
+    {
+      database: z.string(),
+      sql: z.string(),
+      params: z.array(z.union([z.string(), z.number(), z.boolean()])).optional(),
+    },
+    async (args: unknown) => {
+      const { database, sql, params } = args as { database: string; sql: string; params?: (string | number | boolean)[] };
+      return logger.wrap("execute_mutation", args, async () => {
+        try {
+          const adapter = getAdapter(registry, database);
+          const result = await adapter.mutate(sql, params);
+          return { content: [{ type: "text", text: JSON.stringify(result) }] };
+        } catch (err) {
+          return errorResponse(err instanceof Error ? err.message : String(err));
+        }
+      });
+    }
+  );
+}

--- a/tests/sqlite-adapter.test.ts
+++ b/tests/sqlite-adapter.test.ts
@@ -6,14 +6,20 @@ const TEST_DB = "/tmp/test-instant-db-adapter.sqlite";
 
 let adapter: SqliteAdapter;
 
+function cleanupDb() {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    if (existsSync(TEST_DB + suffix)) rmSync(TEST_DB + suffix);
+  }
+}
+
 beforeEach(() => {
-  if (existsSync(TEST_DB)) rmSync(TEST_DB);
+  cleanupDb();
   adapter = new SqliteAdapter(TEST_DB);
 });
 
 afterEach(() => {
   adapter.close();
-  if (existsSync(TEST_DB)) rmSync(TEST_DB);
+  cleanupDb();
 });
 
 describe("SqliteAdapter", () => {
@@ -177,6 +183,63 @@ describe("SqliteAdapter", () => {
       expect(adapter.execute("DROP TABLE fruits")).rejects.toThrow(
         /Only SELECT and WITH/
       );
+    });
+  });
+
+  describe("mutate", () => {
+    beforeEach(async () => {
+      await adapter.createTable({
+        name: "items",
+        columns: [
+          { name: "name", type: "text", required: true },
+          { name: "qty", type: "integer" },
+        ],
+      });
+    });
+
+    it("INSERT returns rowsAffected and lastInsertRowid", async () => {
+      const result = await adapter.mutate("INSERT INTO items (name, qty) VALUES (?, ?)", ["apple", 5]);
+      expect(result.rowsAffected).toBe(1);
+      expect(result.lastInsertRowid).toBe(1);
+    });
+
+    it("UPDATE updates matching rows", async () => {
+      await adapter.mutate("INSERT INTO items (name, qty) VALUES (?, ?)", ["apple", 5]);
+      await adapter.mutate("INSERT INTO items (name, qty) VALUES (?, ?)", ["banana", 3]);
+      const result = await adapter.mutate("UPDATE items SET qty = 10 WHERE name = ?", ["apple"]);
+      expect(result.rowsAffected).toBe(1);
+    });
+
+    it("DELETE deletes matching rows", async () => {
+      await adapter.mutate("INSERT INTO items (name, qty) VALUES (?, ?)", ["apple", 5]);
+      await adapter.mutate("INSERT INTO items (name, qty) VALUES (?, ?)", ["banana", 3]);
+      const result = await adapter.mutate("DELETE FROM items WHERE qty < ?", [4]);
+      expect(result.rowsAffected).toBe(1);
+    });
+
+    it("rejects SELECT", async () => {
+      expect(adapter.mutate("SELECT * FROM items")).rejects.toThrow(/not allowed/);
+    });
+
+    it("rejects DROP/CREATE/ALTER", async () => {
+      expect(adapter.mutate("DROP TABLE items")).rejects.toThrow(/not allowed/);
+      expect(adapter.mutate("CREATE TABLE foo (id INTEGER)")).rejects.toThrow(/not allowed/);
+      expect(adapter.mutate("ALTER TABLE items ADD COLUMN x TEXT")).rejects.toThrow(/not allowed/);
+    });
+
+    it("rolls back on error", async () => {
+      await adapter.createTable({
+        name: "uniq",
+        columns: [{ name: "val", type: "text", required: true }],
+      });
+      // Add a unique constraint via raw db access
+      await adapter.execute("SELECT 1"); // just verifying adapter works
+      await adapter.mutate("INSERT INTO uniq (val) VALUES (?)", ["a"]);
+      // Inserting a row with NULL for NOT NULL column should fail
+      expect(adapter.mutate("INSERT INTO uniq (val) VALUES (NULL)")).rejects.toThrow();
+      // Original row should still be there
+      const rows = await adapter.execute("SELECT * FROM uniq");
+      expect(rows.length).toBe(1);
     });
   });
 

--- a/tests/tools-mutation.test.ts
+++ b/tests/tools-mutation.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { rmSync, existsSync } from "fs";
+import { DatabaseRegistry } from "../src/db/registry.ts";
+import { Logger } from "../src/logger.ts";
+import { registerMutationTools } from "../src/tools/mutation.ts";
+import { registerSchemaTools } from "../src/tools/schema.ts";
+
+const TEST_DIR = "/tmp/test-instant-db-tools-mutation";
+const TEST_LOG = "/tmp/test-instant-db-tools-mutation.log";
+
+function cleanup() {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  if (existsSync(TEST_LOG)) rmSync(TEST_LOG);
+}
+
+function makeFakeServer() {
+  const tools: Record<string, (args: unknown) => Promise<unknown>> = {};
+  return {
+    tool(name: string, _desc: string, _schema: object, handler: (args: unknown) => Promise<unknown>) {
+      tools[name] = handler;
+    },
+    call(name: string, args: unknown) {
+      const fn = tools[name];
+      if (!fn) throw new Error(`Tool ${name} not registered`);
+      return fn(args);
+    },
+  };
+}
+
+type McpResult = { content: { text: string }[]; isError?: boolean };
+
+beforeEach(cleanup);
+afterEach(cleanup);
+
+describe("execute_mutation tool", () => {
+  let server: ReturnType<typeof makeFakeServer>;
+  let registry: DatabaseRegistry;
+  let logger: Logger;
+
+  beforeEach(async () => {
+    registry = new DatabaseRegistry(TEST_DIR);
+    logger = new Logger({ LOG_LEVEL: "off", LOG_PATH: TEST_LOG });
+    server = makeFakeServer();
+    registerSchemaTools(server, registry, logger);
+    registerMutationTools(server, registry, logger);
+
+    // Create a test database with a table
+    await server.call("create_database", {
+      database: "testdb",
+      tables: [
+        {
+          name: "items",
+          columns: [
+            { name: "name", type: "text", required: true },
+            { name: "qty", type: "integer" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("inserts via SQL", async () => {
+    const res = await server.call("execute_mutation", {
+      database: "testdb",
+      sql: "INSERT INTO items (name, qty) VALUES ('apple', 5)",
+    }) as McpResult;
+    const data = JSON.parse(res.content[0]!.text);
+    expect(data.rowsAffected).toBe(1);
+    expect(data.lastInsertRowid).toBe(1);
+  });
+
+  it("UPDATE WHERE affects correct rows", async () => {
+    await server.call("execute_mutation", {
+      database: "testdb",
+      sql: "INSERT INTO items (name, qty) VALUES ('apple', 5)",
+    });
+    await server.call("execute_mutation", {
+      database: "testdb",
+      sql: "INSERT INTO items (name, qty) VALUES ('banana', 3)",
+    });
+
+    const res = await server.call("execute_mutation", {
+      database: "testdb",
+      sql: "UPDATE items SET qty = 99 WHERE name = 'apple'",
+    }) as McpResult;
+    const data = JSON.parse(res.content[0]!.text);
+    expect(data.rowsAffected).toBe(1);
+  });
+
+  it("DELETE WHERE affects correct rows", async () => {
+    await server.call("execute_mutation", {
+      database: "testdb",
+      sql: "INSERT INTO items (name, qty) VALUES ('apple', 5)",
+    });
+    await server.call("execute_mutation", {
+      database: "testdb",
+      sql: "INSERT INTO items (name, qty) VALUES ('banana', 3)",
+    });
+
+    const res = await server.call("execute_mutation", {
+      database: "testdb",
+      sql: "DELETE FROM items WHERE qty < 4",
+    }) as McpResult;
+    const data = JSON.parse(res.content[0]!.text);
+    expect(data.rowsAffected).toBe(1);
+  });
+
+  it("supports bind params", async () => {
+    const res = await server.call("execute_mutation", {
+      database: "testdb",
+      sql: "INSERT INTO items (name, qty) VALUES (?, ?)",
+      params: ["pear", 7],
+    }) as McpResult;
+    const data = JSON.parse(res.content[0]!.text);
+    expect(data.rowsAffected).toBe(1);
+  });
+
+  it("rejects SELECT/DROP/ALTER/CREATE", async () => {
+    for (const sql of [
+      "SELECT * FROM items",
+      "DROP TABLE items",
+      "ALTER TABLE items ADD COLUMN x TEXT",
+      "CREATE TABLE foo (id INTEGER)",
+    ]) {
+      const res = await server.call("execute_mutation", {
+        database: "testdb",
+        sql,
+      }) as McpResult;
+      expect(res.isError).toBe(true);
+      const data = JSON.parse(res.content[0]!.text);
+      expect(data.error).toMatch(/not allowed/);
+    }
+  });
+
+  it("rejects non-existent database", async () => {
+    const res = await server.call("execute_mutation", {
+      database: "nope",
+      sql: "INSERT INTO items (name, qty) VALUES ('x', 1)",
+    }) as McpResult;
+    expect(res.isError).toBe(true);
+    const data = JSON.parse(res.content[0]!.text);
+    expect(data.error).toMatch(/does not exist/);
+  });
+
+  it("returns error on constraint violation", async () => {
+    const res = await server.call("execute_mutation", {
+      database: "testdb",
+      sql: "INSERT INTO items (name, qty) VALUES (NULL, 1)",
+    }) as McpResult;
+    expect(res.isError).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `mutate()` method to `IDbAdapter`/`SqliteAdapter` — runs INSERT/UPDATE/DELETE inside a transaction, rejects SELECT/DDL
- Creates `execute_mutation` MCP tool with database, sql, and optional params
- Registers the tool in the server

## Test plan
- [x] `bun test` — 86 tests pass (7 new adapter tests + 7 new tool tests)
- [ ] Manual: create a database, bulk insert via `execute_mutation`, verify with `execute_query`

🤖 Generated with [Claude Code](https://claude.com/claude-code)