### PR TITLE
Remove propose_schema tool (MCPDB-1)

### DIFF
--- a/docs/getting-started/claude-desktop-setup.mdx
+++ b/docs/getting-started/claude-desktop-setup.mdx
@@ -64,7 +64,6 @@ You should see these tools available:
 
 - `list_databases`
 - `describe_database`
-- `propose_schema`
 - `create_database`
 - `insert_record`
 - `query_records`
@@ -83,8 +82,7 @@ You have access to an instant-db MCP server for persistent structured storage.
 When a user wants to track or store anything structured:
 
 1. Call list_databases first to check what already exists.
-2. If no relevant database exists, call propose_schema and present the proposal
-   conversationally — don't show raw JSON.
+2. If no relevant database exists, propose a schema conversationally.
 3. Wait for explicit confirmation before calling create_database.
 4. At the start of any session involving an existing database, call
    describe_database so you know the current schema before inserting or querying.

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -34,7 +34,7 @@ You never write SQL. You never define a schema. You describe what you want to tr
     Tell Claude what you want to track. "I want to log my daily meals and calories."
   </Step>
   <Step title="Review the proposed schema">
-    Claude calls `propose_schema` and presents the table structure in plain English. You can ask for changes.
+    Claude proposes the table structure in plain English. You can ask for changes.
   </Step>
   <Step title="Confirm and create">
     Say "looks good" and Claude calls `create_database`. Your SQLite file is created instantly.

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -78,10 +78,9 @@ Once connected to Claude Desktop, open a new conversation and say:
 > "I want to track my daily water intake — date, glasses of water, and any notes."
 
 Claude will:
-1. Call `propose_schema` and describe the table structure to you
-2. Wait for your confirmation
-3. Call `create_database` to create it
-4. Be ready to insert and query records immediately
+1. Propose a table structure conversationally and wait for your confirmation
+2. Call `create_database` to create it
+3. Be ready to insert and query records immediately
 
 <Tip>
   Add the [recommended system prompt](/getting-started/claude-desktop-setup#system-prompt) to Claude so it automatically checks for existing databases at the start of each session.

--- a/docs/guides/calorie-diary.mdx
+++ b/docs/guides/calorie-diary.mdx
@@ -28,7 +28,7 @@ In this guide you'll build a personal calorie diary using nothing but conversati
 
     > "I want to build a calorie diary. I need to track the foods I eat — name, calories, and macros (protein, carbs, fat). I also need a daily log where I record each meal with date, meal name (breakfast/lunch/dinner/snack), the food, how many servings, and total calories."
 
-    Claude will call `propose_schema` and respond with something like:
+    Claude will propose a schema and respond with something like:
 
     > "I'd suggest two tables:
     >

--- a/docs/reference/tools.mdx
+++ b/docs/reference/tools.mdx
@@ -4,7 +4,7 @@ description: "Every MCP tool exposed by instant-db, with inputs, outputs, and ex
 icon: "wrench"
 ---
 
-instant-db exposes 9 MCP tools. All inputs are validated with [Zod](https://zod.dev) at runtime. All outputs are JSON strings inside an MCP content block.
+instant-db exposes 8 MCP tools. All inputs are validated with [Zod](https://zod.dev) at runtime. All outputs are JSON strings inside an MCP content block.
 
 ---
 
@@ -69,27 +69,6 @@ Returns the full schema of a named database — every table, column name, type, 
 ---
 
 ## Schema tools
-
-### `propose_schema`
-
-Given a plain-language description, returns a structured schema proposal. **This tool does not create anything.** Claude presents the result conversationally and waits for confirmation.
-
-If `existing_proposal` is passed (from a previous call), the server returns it back so Claude can modify it based on the user's change request. This keeps the iteration loop stateless on the server side.
-
-<ParamField body="description" type="string" required>
-  Plain-language description of what to track.
-</ParamField>
-
-<ParamField body="existing_proposal" type="TableSchema[]">
-  A previous proposal to iterate on. Optional.
-</ParamField>
-
-**Output:**
-<ResponseField name="tables" type="TableSchema[]">The proposed schema.</ResponseField>
-<ResponseField name="summary" type="string">Human-readable summary for Claude to present.</ResponseField>
-<ResponseField name="description" type="string">The original description, echoed back.</ResponseField>
-
----
 
 ### `create_database`
 

--- a/src/tools/schema.ts
+++ b/src/tools/schema.ts
@@ -21,30 +21,6 @@ const TableSchemaInput = z.object({
 
 export function registerSchemaTools(server: ToolServer, registry: DatabaseRegistry, logger: Logger) {
   server.tool(
-    "propose_schema",
-    "Given a plain-language description, return a structured schema proposal. Does NOT create anything — only proposes. Present the result conversationally and wait for user confirmation.",
-    {
-      description: z.string().describe("Plain-language description of what the user wants to track"),
-      existing_proposal: z.array(TableSchemaInput).optional().describe("Existing proposal to iterate on"),
-    },
-    async (args: unknown) => {
-      const { description, existing_proposal } = args as {
-        description: string;
-        existing_proposal?: TableSchema[];
-      };
-      return logger.wrap("propose_schema", args, async () => {
-        const tables: TableSchema[] = existing_proposal ?? [];
-        const summary = existing_proposal
-          ? `Returning existing proposal for modification based on: "${description}"`
-          : `Schema proposal for: "${description}"`;
-        return {
-          content: [{ type: "text", text: JSON.stringify({ tables, summary, description }) }],
-        };
-      });
-    }
-  );
-
-  server.tool(
     "create_database",
     "Create a named database from a confirmed schema. Fails if the database already exists.",
     {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -55,14 +55,7 @@ describe("Integration: workout tracker", () => {
     let data = JSON.parse(res.content[0]!.text);
     expect(data.databases).toEqual([]);
 
-    // 2. Propose a schema
-    res = await server.call("propose_schema", {
-      description: "I want to track my workouts — exercises, sets, reps, and weights",
-    }) as McpResult;
-    data = JSON.parse(res.content[0]!.text);
-    expect(data.description).toContain("workouts");
-
-    // 3. Create the database with confirmed schema
+    // 2. Create the database with confirmed schema
     res = await server.call("create_database", {
       database: "workouts",
       tables: [
@@ -89,19 +82,19 @@ describe("Integration: workout tracker", () => {
     data = JSON.parse(res.content[0]!.text);
     expect(data.success).toBe(true);
 
-    // 4. List databases — should now include "workouts"
+    // 3. List databases — should now include "workouts"
     res = await server.call("list_databases", {}) as McpResult;
     data = JSON.parse(res.content[0]!.text);
     expect(data.databases).toContain("workouts");
 
-    // 5. Describe the database
+    // 4. Describe the database
     res = await server.call("describe_database", { database: "workouts" }) as McpResult;
     data = JSON.parse(res.content[0]!.text);
     const tableNames = data.tables.map((t: { name: string }) => t.name);
     expect(tableNames).toContain("exercises");
     expect(tableNames).toContain("workout_logs");
 
-    // 6. Insert an exercise
+    // 5. Insert an exercise
     res = await server.call("insert_record", {
       database: "workouts",
       table: "exercises",
@@ -110,7 +103,7 @@ describe("Integration: workout tracker", () => {
     data = JSON.parse(res.content[0]!.text);
     expect(data.id).toBe(1);
 
-    // 7. Log a workout
+    // 6. Log a workout
     res = await server.call("insert_record", {
       database: "workouts",
       table: "workout_logs",
@@ -127,7 +120,7 @@ describe("Integration: workout tracker", () => {
     const logId = data.id as number;
     expect(logId).toBe(1);
 
-    // 8. Query all workout logs
+    // 7. Query all workout logs
     res = await server.call("query_records", {
       database: "workouts",
       table: "workout_logs",
@@ -138,7 +131,7 @@ describe("Integration: workout tracker", () => {
     expect(data.records[0].exercise).toBe("Squat");
     expect(data.records[0].weight_lbs).toBe(185);
 
-    // 9. Query with filter (mood = great)
+    // 8. Query with filter (mood = great)
     res = await server.call("query_records", {
       database: "workouts",
       table: "workout_logs",
@@ -147,7 +140,7 @@ describe("Integration: workout tracker", () => {
     data = JSON.parse(res.content[0]!.text);
     expect(data.count).toBe(1);
 
-    // 10. Update the weight
+    // 9. Update the weight
     res = await server.call("update_record", {
       database: "workouts",
       table: "workout_logs",
@@ -157,7 +150,7 @@ describe("Integration: workout tracker", () => {
     data = JSON.parse(res.content[0]!.text);
     expect(data.success).toBe(true);
 
-    // 11. Count records
+    // 10. Count records
     res = await server.call("count_records", {
       database: "workouts",
       table: "workout_logs",
@@ -165,7 +158,7 @@ describe("Integration: workout tracker", () => {
     data = JSON.parse(res.content[0]!.text);
     expect(data.count).toBe(1);
 
-    // 12. Delete the log
+    // 11. Delete the log
     res = await server.call("delete_record", {
       database: "workouts",
       table: "workout_logs",
@@ -174,7 +167,7 @@ describe("Integration: workout tracker", () => {
     data = JSON.parse(res.content[0]!.text);
     expect(data.success).toBe(true);
 
-    // 13. Count again — should be 0
+    // 12. Count again — should be 0
     res = await server.call("count_records", {
       database: "workouts",
       table: "workout_logs",

--- a/tests/tools-schema.test.ts
+++ b/tests/tools-schema.test.ts
@@ -41,37 +41,6 @@ describe("schema tools", () => {
     registerSchemaTools(server, registry, logger);
   });
 
-  describe("propose_schema", () => {
-    it("returns description and tables structure", async () => {
-      const result = await server.call("propose_schema", {
-        description: "I want to track workouts",
-      }) as { content: { text: string }[] };
-
-      const data = JSON.parse(result.content[0]!.text);
-      expect(data.description).toBe("I want to track workouts");
-      expect(Array.isArray(data.tables)).toBe(true);
-      expect(typeof data.summary).toBe("string");
-    });
-
-    it("returns existing_proposal when provided", async () => {
-      const existing = [
-        {
-          name: "exercises",
-          columns: [{ name: "name", type: "text", required: true }],
-        },
-      ];
-
-      const result = await server.call("propose_schema", {
-        description: "Add a notes field",
-        existing_proposal: existing,
-      }) as { content: { text: string }[] };
-
-      const data = JSON.parse(result.content[0]!.text);
-      expect(data.tables).toHaveLength(1);
-      expect(data.tables[0].name).toBe("exercises");
-    });
-  });
-
   describe("create_database", () => {
     it("creates a database with tables", async () => {
       const result = await server.call("create_database", {


### PR DESCRIPTION
## Summary
- Removes `propose_schema` tool registration from `schema.ts` — it was a no-op returning empty tables
- Removes associated tests from `tools-schema.test.ts` and `integration.test.ts`
- Updates all docs referencing `propose_schema` (tools reference, quick start, introduction, Claude Desktop setup, calorie diary guide)

## Test plan
- [x] `bun test` — 84 tests pass
- [ ] Manual: ask Claude to create a database, verify it proposes schema conversationally and goes straight to `create_database`

🤖 Generated with [Claude Code](https://claude.com/claude-code)