### PR TITLE
Migrate registry from JSON to _metadata.sqlite (MCPDB-7)

### DIFF
--- a/src/db/registry.ts
+++ b/src/db/registry.ts
@@ -1,44 +1,81 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { Database } from "bun:sqlite";
+import { existsSync, mkdirSync, readFileSync, renameSync } from "fs";
 import { join } from "path";
 import type { IDbAdapter } from "./adapter.ts";
 import { SqliteAdapter } from "./sqlite.ts";
 
-interface RegistryEntry {
-  name: string;
-  path: string;
-  createdAt: string;
-}
-
-interface RegistryManifest {
-  databases: RegistryEntry[];
-}
-
 export class DatabaseRegistry {
   private adapters: Map<string, SqliteAdapter> = new Map();
-  private manifest: RegistryManifest = { databases: [] };
-  private manifestPath: string;
+  private metaDb: Database;
   private dataDir: string;
 
   constructor(dataDir: string) {
     this.dataDir = dataDir;
-    this.manifestPath = join(dataDir, "_registry.json");
 
     if (!existsSync(dataDir)) {
       mkdirSync(dataDir, { recursive: true });
     }
 
-    if (existsSync(this.manifestPath)) {
-      const raw = readFileSync(this.manifestPath, "utf-8");
-      this.manifest = JSON.parse(raw) as RegistryManifest;
+    const metaPath = join(dataDir, "_metadata.sqlite");
+    const jsonPath = join(dataDir, "_registry.json");
+    const needsMigration = existsSync(jsonPath) && !existsSync(metaPath);
+
+    this.metaDb = new Database(metaPath);
+    this.metaDb.run("PRAGMA journal_mode = WAL");
+    this.metaDb.run("PRAGMA foreign_keys = ON");
+
+    this.metaDb.run(`
+      CREATE TABLE IF NOT EXISTS databases (
+        name TEXT PRIMARY KEY,
+        path TEXT NOT NULL,
+        description TEXT,
+        notes TEXT,
+        created_at TEXT NOT NULL
+      )
+    `);
+
+    this.metaDb.run(`
+      CREATE TABLE IF NOT EXISTS fields (
+        database_name TEXT NOT NULL,
+        table_name TEXT NOT NULL,
+        column_name TEXT NOT NULL,
+        display_name TEXT,
+        description TEXT,
+        PRIMARY KEY (database_name, table_name, column_name),
+        FOREIGN KEY (database_name) REFERENCES databases(name)
+      )
+    `);
+
+    if (needsMigration) {
+      this.migrateFromJson(jsonPath);
     }
   }
 
+  private migrateFromJson(jsonPath: string): void {
+    const raw = readFileSync(jsonPath, "utf-8");
+    const manifest = JSON.parse(raw) as { databases: { name: string; path: string; createdAt: string }[] };
+
+    const insert = this.metaDb.prepare(
+      "INSERT OR IGNORE INTO databases (name, path, created_at) VALUES (?, ?, ?)"
+    );
+    const txn = this.metaDb.transaction(() => {
+      for (const entry of manifest.databases) {
+        insert.run(entry.name, entry.path, entry.createdAt);
+      }
+    });
+    txn();
+
+    renameSync(jsonPath, jsonPath + ".bak");
+  }
+
   list(): string[] {
-    return this.manifest.databases.map((d) => d.name);
+    const rows = this.metaDb.query("SELECT name FROM databases").all() as { name: string }[];
+    return rows.map((r) => r.name);
   }
 
   exists(name: string): boolean {
-    return this.manifest.databases.some((d) => d.name === name);
+    const row = this.metaDb.query("SELECT 1 FROM databases WHERE name = ?").get(name);
+    return row !== null;
   }
 
   get(name: string): IDbAdapter {
@@ -47,8 +84,8 @@ export class DatabaseRegistry {
     }
 
     if (!this.adapters.has(name)) {
-      const entry = this.manifest.databases.find((d) => d.name === name)!;
-      this.adapters.set(name, new SqliteAdapter(entry.path));
+      const row = this.metaDb.query("SELECT path FROM databases WHERE name = ?").get(name) as { path: string };
+      this.adapters.set(name, new SqliteAdapter(row.path));
     }
 
     return this.adapters.get(name)!;
@@ -69,18 +106,15 @@ export class DatabaseRegistry {
     const adapter = new SqliteAdapter(filePath);
     this.adapters.set(name, adapter);
 
-    const entry: RegistryEntry = {
-      name,
-      path: filePath,
-      createdAt: new Date().toISOString(),
-    };
-    this.manifest.databases.push(entry);
-    this.saveManifest();
+    this.metaDb.run(
+      "INSERT INTO databases (name, path, created_at) VALUES (?, ?, ?)",
+      [name, filePath, new Date().toISOString()]
+    );
 
     return adapter;
   }
 
-  private saveManifest(): void {
-    writeFileSync(this.manifestPath, JSON.stringify(this.manifest, null, 2), "utf-8");
+  close(): void {
+    this.metaDb.close();
   }
 }

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { rmSync, existsSync } from "fs";
+import { rmSync, existsSync, writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
 import { DatabaseRegistry } from "../src/db/registry.ts";
 
 const TEST_DIR = "/tmp/test-instant-db-registry";
@@ -72,12 +73,64 @@ describe("DatabaseRegistry", () => {
     expect(id).toBe(1);
   });
 
-  it("persists manifest across instances", async () => {
+  it("persists across instances via _metadata.sqlite", async () => {
     const r1 = new DatabaseRegistry(TEST_DIR);
     await r1.create("mydb");
+    r1.close();
 
     const r2 = new DatabaseRegistry(TEST_DIR);
     expect(r2.list()).toContain("mydb");
     expect(r2.exists("mydb")).toBe(true);
+  });
+
+  it("cold start with no existing registry creates empty _metadata.sqlite", () => {
+    const registry = new DatabaseRegistry(TEST_DIR);
+    expect(registry.list()).toEqual([]);
+    expect(existsSync(join(TEST_DIR, "_metadata.sqlite"))).toBe(true);
+  });
+
+  describe("migration from _registry.json", () => {
+    it("migrates entries from JSON to SQLite", () => {
+      mkdirSync(TEST_DIR, { recursive: true });
+      const manifest = {
+        databases: [
+          { name: "calories", path: join(TEST_DIR, "calories.sqlite"), createdAt: "2024-01-01T00:00:00.000Z" },
+          { name: "workouts", path: join(TEST_DIR, "workouts.sqlite"), createdAt: "2024-02-01T00:00:00.000Z" },
+        ],
+      };
+      writeFileSync(join(TEST_DIR, "_registry.json"), JSON.stringify(manifest, null, 2), "utf-8");
+
+      const registry = new DatabaseRegistry(TEST_DIR);
+      expect(registry.list()).toContain("calories");
+      expect(registry.list()).toContain("workouts");
+      expect(registry.exists("calories")).toBe(true);
+      expect(registry.exists("workouts")).toBe(true);
+    });
+
+    it("creates _registry.json.bak after migration", () => {
+      mkdirSync(TEST_DIR, { recursive: true });
+      const manifest = { databases: [{ name: "db1", path: join(TEST_DIR, "db1.sqlite"), createdAt: "2024-01-01T00:00:00.000Z" }] };
+      writeFileSync(join(TEST_DIR, "_registry.json"), JSON.stringify(manifest), "utf-8");
+
+      new DatabaseRegistry(TEST_DIR);
+      expect(existsSync(join(TEST_DIR, "_registry.json.bak"))).toBe(true);
+      expect(existsSync(join(TEST_DIR, "_registry.json"))).toBe(false);
+    });
+
+    it("does not re-migrate if _metadata.sqlite already exists", async () => {
+      // First: create a registry with SQLite metadata
+      const r1 = new DatabaseRegistry(TEST_DIR);
+      await r1.create("existing");
+      r1.close();
+
+      // Place a JSON file (simulating leftover)
+      const manifest = { databases: [{ name: "from-json", path: join(TEST_DIR, "from-json.sqlite"), createdAt: "2024-01-01T00:00:00.000Z" }] };
+      writeFileSync(join(TEST_DIR, "_registry.json"), JSON.stringify(manifest), "utf-8");
+
+      // Re-open — should NOT migrate because _metadata.sqlite already exists
+      const r2 = new DatabaseRegistry(TEST_DIR);
+      expect(r2.list()).toContain("existing");
+      expect(r2.exists("from-json")).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Rewrites `DatabaseRegistry` to use `bun:sqlite` instead of `_registry.json`
- Creates `databases` and `fields` tables (fields table lays groundwork for MCPDB-5/MCPDB-6)
- Auto-migrates existing `_registry.json` to SQLite on first run, renames to `_registry.json.bak`
- Adds `close()` method for clean shutdown
- Public API unchanged — all existing consumers work without modification

## Test plan
- [x] `bun test` — 88 tests pass (4 new migration/cold-start tests)
- [ ] Manual: verify existing databases (e.g. `calorie-diary`) still appear in `list_databases`
- [ ] Manual: check `data/_metadata.sqlite` exists and `data/_registry.json.bak` was created

🤖 Generated with [Claude Code](https://claude.com/claude-code)