### PR TITLE
MCPDB-10: Add delete_database tool

### DIFF
--- a/src/db/registry.ts
+++ b/src/db/registry.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { existsSync, mkdirSync, readFileSync, renameSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync } from "fs";
 import { join } from "path";
 import type { IDbAdapter } from "./adapter.ts";
 import { SqliteAdapter } from "./sqlite.ts";
@@ -159,6 +159,30 @@ export class DatabaseRegistry {
     );
 
     return adapter;
+  }
+
+  delete(name: string): void {
+    if (!this.exists(name)) {
+      throw new Error(`Database "${name}" does not exist`);
+    }
+
+    const row = this.metaDb.query("SELECT path FROM databases WHERE name = ?").get(name) as { path: string };
+
+    // Close the adapter if it's open
+    const adapter = this.adapters.get(name);
+    if (adapter) {
+      adapter.close();
+      this.adapters.delete(name);
+    }
+
+    // Remove metadata (fields cascade via manual delete since SQLite FK doesn't auto-cascade on DELETE by default in all modes)
+    this.metaDb.run("DELETE FROM fields WHERE database_name = ?", [name]);
+    this.metaDb.run("DELETE FROM databases WHERE name = ?", [name]);
+
+    // Delete the SQLite file from disk
+    if (existsSync(row.path)) {
+      rmSync(row.path);
+    }
   }
 
   close(): void {

--- a/src/tools/database.ts
+++ b/src/tools/database.ts
@@ -87,6 +87,36 @@ export function registerDatabaseTools(server: ToolServer, registry: DatabaseRegi
   );
 
   server.tool(
+    "delete_database",
+    "Permanently delete a database, its SQLite file, and all associated metadata. Requires confirm=true to proceed. This action cannot be undone.",
+    {
+      database: z.string().describe("The name of the database to delete"),
+      confirm: z.boolean().optional().describe("Must be true to confirm deletion"),
+    },
+    async (args: unknown) => {
+      const { database, confirm } = args as { database: string; confirm?: boolean };
+      return logger.wrap("delete_database", args, async () => {
+        if (!confirm) {
+          return {
+            content: [{ type: "text", text: JSON.stringify({ error: "You must pass confirm: true to delete a database. This action is irreversible." }) }],
+            isError: true,
+          };
+        }
+        if (!registry.exists(database)) {
+          return {
+            content: [{ type: "text", text: JSON.stringify({ error: `Database "${database}" does not exist` }) }],
+            isError: true,
+          };
+        }
+        registry.delete(database);
+        return {
+          content: [{ type: "text", text: JSON.stringify({ success: true, deleted: database }) }],
+        };
+      });
+    }
+  );
+
+  server.tool(
     "update_field_metadata",
     "Set a display name and/or description on a column. Use this to document what a field means, its valid values, units, or formatting rules. Field metadata is returned by describe_database.",
     {

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -233,6 +233,63 @@ describe("DatabaseRegistry", () => {
     });
   });
 
+  describe("delete", () => {
+    it("removes database from list", async () => {
+      const registry = new DatabaseRegistry(TEST_DIR);
+      await registry.create("mydb");
+      expect(registry.exists("mydb")).toBe(true);
+      registry.delete("mydb");
+      expect(registry.exists("mydb")).toBe(false);
+      expect(registry.list()).not.toContain("mydb");
+    });
+
+    it("deletes the sqlite file from disk", async () => {
+      const registry = new DatabaseRegistry(TEST_DIR);
+      await registry.create("mydb");
+      const dbPath = join(TEST_DIR, "mydb.sqlite");
+      expect(existsSync(dbPath)).toBe(true);
+      registry.delete("mydb");
+      expect(existsSync(dbPath)).toBe(false);
+    });
+
+    it("removes associated field metadata", async () => {
+      const registry = new DatabaseRegistry(TEST_DIR);
+      await registry.create("mydb");
+      registry.updateFieldMetadata("mydb", "meals", "cal", "Calories", "kcal");
+      expect(registry.getFieldsMetadata("mydb")).toHaveLength(1);
+      registry.delete("mydb");
+      // After deletion, getFieldsMetadata should throw since db doesn't exist
+      expect(() => registry.getFieldsMetadata("mydb")).toThrow(/does not exist/);
+    });
+
+    it("throws for non-existent database", () => {
+      const registry = new DatabaseRegistry(TEST_DIR);
+      expect(() => registry.delete("missing")).toThrow(/does not exist/);
+    });
+
+    it("allows re-creating a deleted database", async () => {
+      const registry = new DatabaseRegistry(TEST_DIR);
+      await registry.create("mydb");
+      registry.delete("mydb");
+      const adapter = await registry.create("mydb");
+      expect(registry.exists("mydb")).toBe(true);
+      await adapter.createTable({ name: "t", columns: [{ name: "x", type: "text" }] });
+      const tables = await adapter.getTables();
+      expect(tables.map((t) => t.name)).toContain("t");
+    });
+
+    it("persists deletion across instances", async () => {
+      const r1 = new DatabaseRegistry(TEST_DIR);
+      await r1.create("mydb");
+      r1.delete("mydb");
+      r1.close();
+
+      const r2 = new DatabaseRegistry(TEST_DIR);
+      expect(r2.exists("mydb")).toBe(false);
+      expect(r2.list()).not.toContain("mydb");
+    });
+  });
+
   describe("migration from _registry.json", () => {
     it("migrates entries from JSON to SQLite", () => {
       mkdirSync(TEST_DIR, { recursive: true });

--- a/tests/tools-database.test.ts
+++ b/tests/tools-database.test.ts
@@ -141,6 +141,70 @@ describe("database tools", () => {
     });
   });
 
+  describe("delete_database", () => {
+    it("deletes an existing database", async () => {
+      await registry.create("mydb");
+
+      const result = await server.call("delete_database", {
+        database: "mydb",
+        confirm: true,
+      }) as { content: { text: string }[] };
+
+      const data = JSON.parse(result.content[0]!.text);
+      expect(data.success).toBe(true);
+      expect(registry.exists("mydb")).toBe(false);
+    });
+
+    it("returns error without confirm flag", async () => {
+      await registry.create("mydb");
+
+      const result = await server.call("delete_database", {
+        database: "mydb",
+      }) as { isError: boolean; content: { text: string }[] };
+
+      expect(result.isError).toBe(true);
+      const data = JSON.parse(result.content[0]!.text);
+      expect(data.error).toMatch(/confirm/i);
+      // Database should still exist
+      expect(registry.exists("mydb")).toBe(true);
+    });
+
+    it("returns error with confirm=false", async () => {
+      await registry.create("mydb");
+
+      const result = await server.call("delete_database", {
+        database: "mydb",
+        confirm: false,
+      }) as { isError: boolean; content: { text: string }[] };
+
+      expect(result.isError).toBe(true);
+      expect(registry.exists("mydb")).toBe(true);
+    });
+
+    it("returns error for non-existent database", async () => {
+      const result = await server.call("delete_database", {
+        database: "missing",
+        confirm: true,
+      }) as { isError: boolean; content: { text: string }[] };
+
+      expect(result.isError).toBe(true);
+      const data = JSON.parse(result.content[0]!.text);
+      expect(data.error).toMatch(/does not exist/);
+    });
+
+    it("database no longer appears in list_databases after deletion", async () => {
+      await registry.create("db1");
+      await registry.create("db2");
+
+      await server.call("delete_database", { database: "db1", confirm: true });
+
+      const result = await server.call("list_databases", {}) as { content: { text: string }[] };
+      const data = JSON.parse(result.content[0]!.text);
+      expect(data.databases).not.toContain("db1");
+      expect(data.databases).toContain("db2");
+    });
+  });
+
   describe("describe_database with field metadata", () => {
     it("includes field metadata on columns", async () => {
       const adapter = await registry.create("mydb");


### PR DESCRIPTION
## Summary
- Add `DatabaseRegistry.delete()` method that closes the adapter, removes metadata from both `databases` and `fields` tables, and deletes the SQLite file from disk
- Add `delete_database` MCP tool with a required `confirm: true` safety parameter to prevent accidental deletion
- 11 new tests covering registry-level deletion and tool-level behavior (confirm guard, non-existent DB, list verification)

## Files changed
- `src/db/registry.ts` — new `delete()` method
- `src/tools/database.ts` — new `delete_database` tool
- `tests/registry.test.ts` — 6 new registry tests
- `tests/tools-database.test.ts` — 5 new tool tests

## Test plan
- [x] All 135 tests pass (`bun test`)
- [ ] Manual test: create a database via MCP, then delete it with `confirm: true`
- [ ] Verify the `.sqlite` file is removed from `data/`
- [ ] Verify it no longer appears in `list_databases`

🤖 Generated with [Claude Code](https://claude.com/claude-code)